### PR TITLE
Added ajax capabilities

### DIFF
--- a/assets/subscribe.js
+++ b/assets/subscribe.js
@@ -1,19 +1,27 @@
-/* simple jquery plugin for the mail chimp ajax form */
+/**
+ * Simple jquery plugin for the mail chimp ajax form
+ * 
+ * As for the normal use of this extention, be sure to include all merge fields
+ * 
+ * Basic Usage
+ * 
+ * $('#the-form').mailchimp({
+ * 		complete: completeCallback(data), // this is set to #the-form
+ * 		error: errorCallback(data) // data.error -> error message
+ * });
+ * 
+ * @author nicolasbrassard - http://www.nitriques.com
+ *  */
 
 (function ($, undefined) {
 	
 	var defaults = {
-		/*emailField : '#email',
-		mergeFields : [
-		               {'FNAME': '#fname'},
-		               {'LNAME': '#lname'}
-		              ],*/
 		complete : $.noop,
 		error: $.noop,
 		url: '/symphony/extension/mailchimp/subscribe/'
 	};
 	
-	// actual plusgin
+	// actual plugin
 	function mailchimp(options) {
 		var t = $(this),
 			opts = $.extend({}, defaults, options);
@@ -33,24 +41,10 @@
 					e.preventDefault();
 				}
 				
-				/*var data = {
-						email : $(opts.emailField, t).val()
-				}
-				
-				// merge fields
-				for (var m in opts.mergeFields) {
-					alert(m);
-					
-					var f = opts.mergeFields[m],
-						val = $(f[1], t).val();
-					
-					data['merge['+f[0]+']'] = val;
-				}*/
-				
 				// gets the POST params
 				var data = t.serialize();
 				
-				// adds the bouton field
+				// adds the button field
 				data += '&' + escape('action[signup]') + '=Send';
 			
 				// ajax request
@@ -68,7 +62,6 @@
 								if ($.isFunction(opts.complete)) {
 									opts.complete.call(t, data);
 								}
-								
 							} 
 							
 						} else {
@@ -77,10 +70,13 @@
 								opts.error.call(t, data);
 							}
 						}
-						
-					
 					} ,
-					error: opts.error
+					error: function (data) {
+						
+						if ($.isFunction(opts.error)) {
+							opts.error.call(t, data);
+						}
+					}
 				});
 				
 				return false;

--- a/content/content.subscribe.php
+++ b/content/content.subscribe.php
@@ -41,18 +41,21 @@
 				$output = array('error' => __('Error, could not process the request'));
 			}
 			
+			// set body of the response
 			$this->_Result = json_encode($output);
-			
-			//var_dump($this->_Result);
 		}
 		
 	}
 	
-	
+	/**
+	 * Abstract class that sets basic params for a JSON page
+	 * @author nicolasbrassard
+	 *
+	 */
 	Abstract Class JSONPage extends Page {
 		
 		/**
-		 * Method that build the result send to the client
+		 * Method that builds the result send to the client
 		 */
 		public abstract function view();
 		
@@ -72,17 +75,11 @@
 			exit;
 		}
 		
+		/**
+		 * Dummy method to be compatible with normal Administration pages
+		 */
 		public function build() {
 			return $this->generate();
 		}
-		
-		/**
-		 * Overrides the default autorisation failed mechanism
-		 */
-		/*public function handleFailedAuthorisation(){
-			// do nothing, we do not want any autorisation on this page
-			$this->_status = self::STATUS_OK;
-			//exit;
-		}*/
 		
 	}


### PR DESCRIPTION
2 files have been added to the project, without modifying anything you made (which was working well)
- A page to fire the event from an ajax request
- A jQuery plugin to capture the submitting of the form

The only thing you need to add to your default form would be

the reference to the /extensions/mailchimp/assets/subscribe.js

and

 $('#the-form').mailchimp({
        complete: completeCallback(data), // "this" keyword is set to #the-form
        error: errorCallback(data) // data.error -> error message
 });

The default form is still working for NON-js browser...

I think this is a neat plus in your ext.
