### PR TITLE
Bug on the event page (Blueprints -> Events -> Mailchimp)

### DIFF
--- a/events/event.mailchimp.php
+++ b/events/event.mailchimp.php
@@ -11,7 +11,7 @@
 		public function __construct(&$parent, $env = null) {
 			parent::__construct($parent, $env);
 
-			$this->_driver = Administration::instance()->ExtensionManager->create('mailchimp');
+			$this->_driver = Symphony::$ExtensionManager->create('mailchimp');
 		}
 
 		public static function about()


### PR DESCRIPTION
Fix a bug on the event page: Change Frontend to Administration class for getting the ExtensionManager instance
