### PR TITLE
Fix for include filename and namespace

### DIFF
--- a/events/event.mailchimp.php
+++ b/events/event.mailchimp.php
@@ -2,7 +2,9 @@
 
 	if(!defined('__IN_SYMPHONY__')) die('<h2>Error</h2><p>You cannot directly access this file</p>');
 
-	include_once(EXTENSIONS . '/mailchimp/lib/mailchimp-api/MailChimp.class.php');
+	include_once(EXTENSIONS . '/mailchimp/lib/mailchimp-api/MailChimp.php');
+
+	use Drewm\MailChimp;
 
 	Class eventMailchimp extends Event
 	{


### PR DESCRIPTION
Since these codebases have been split into separate repositories it looks like this file name was changed and a namespace has been added.

In order to use this extension I had to make the following changes.
