### PR TITLE
Update for Symphony 4.x

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -55,7 +55,7 @@ class extension_mailchimp extends Extension{
             'settings[mailchimp][key]', General::Sanitize($this->getKey())
         ));
         $api->appendChild(
-            new XMLElement('p', Widget::Anchor(__('Generate your API Key'), 'http://kb.mailchimp.com/article/where-can-i-find-my-api-key'), array(
+            new XMLElement('p', Widget::Anchor(__('Generate your API Key'), 'http://kb.mailchimp.com/article/where-can-i-find-my-api-key', null, null, null, array('target' => '_blank')), array(
                 'class' => 'help'
             ))
         );

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -24,6 +24,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="4.0.0" date="TBA" min="4.0.0" max="4.x.x">
+			- Update for 4.x
+		</release>
 		<release version="3.0.1" date="2017-02-28" min="2.6.0" max="2.6.x">
 			- Fix an error with the core JSONPage
 		</release>


### PR DESCRIPTION
Update release version.
Add attribute target-blank to “generate api key” link.
cc @nitriques